### PR TITLE
Implement AEH header branding

### DIFF
--- a/assets/theme.css
+++ b/assets/theme.css
@@ -197,3 +197,72 @@ body {
 .animation-delay-400 {
   animation-delay: 0.4s;
 }
+
+/***** AEH HEADER START *****/
+:root{
+  --aeh-navy:#202D36;
+  --aeh-crimson:#3C0007;
+  --aeh-steel:#929CAA;
+  --aeh-maroon:#6C0102;
+}
+
+.header-wrapper{
+  background:linear-gradient(90deg,var(--aeh-navy) 0%,var(--aeh-crimson) 100%);
+  height:80px;
+  position:sticky;
+  top:0;
+  z-index:50;
+  box-shadow:0 2px 4px rgba(0,0,0,.25);
+}
+
+.header{
+  display:flex;
+  justify-content:space-between;
+  align-items:center;
+  height:100%;
+  padding:0 24px;
+}
+
+.header__heading-logo{
+  width:40px;
+  height:40px;
+}
+
+.header__menu{
+  display:flex;
+  gap:32px;
+}
+
+.header__menu-item{
+  color:#fff;
+  font-size:14px;
+  letter-spacing:.05em;
+  text-transform:uppercase;
+  line-height:1;
+}
+
+.header__menu-item[aria-current='page']{
+  color:var(--aeh-maroon);
+}
+
+.header__icons{
+  display:flex;
+  gap:24px;
+}
+
+.header__icon{
+  width:20px;
+  height:20px;
+  stroke:var(--aeh-steel);
+  fill:none;
+  transition:stroke .15s;
+}
+
+.header__icon:hover{
+  stroke:#fff;
+}
+
+@media(max-width:991px){
+  .header__menu{display:none;}
+}
+/***** AEH HEADER END *****/

--- a/sections/header.liquid
+++ b/sections/header.liquid
@@ -1,73 +1,26 @@
-{%- liquid
-  assign main_menu = section.settings.menu
--%}
-
-<header role="banner" class="header-section relative z-10 w-full bg-white shadow-md">
-  <div class="header-container mx-auto flex items-center justify-between px-4 py-4 sm:px-6 lg:px-8">
-    <div class="header-logo flex-shrink-0">
-      <a href="/" class="text-2xl font-bold text-gray-800 hover:text-gray-600">
-        {{ shop.name }}
+{% comment %} AEH branded header {% endcomment %}
+<header class="header-wrapper">
+  <div class="header">
+    <div class="header__heading">
+      <a href="{{ routes.root_url }}" class="header__heading-link" aria-label="{{ shop.name }}">
+        {%- render 'icon-logo-aeh', class:'header__heading-logo' -%}
       </a>
     </div>
 
-    <nav class="header-navigation hidden md:flex md:items-center md:gap-x-8">
-      {%- for link in main_menu.links -%}
-        <a href="{{ link.url }}" class="text-base font-medium text-gray-500 hover:text-gray-900">
+    <nav class="header__menu" role="navigation">
+      {% for link in linklists.main-menu.links %}
+        <a href="{{ link.url }}"
+           class="header__menu-item"
+           {% if link.active %}aria-current="page"{% endif %}>
           {{ link.title }}
         </a>
-      {%- endfor -%}
+      {% endfor %}
     </nav>
 
-    <div class="header-actions flex items-center gap-x-4">
-      <a href="{{ routes.cart_url }}" class="text-base font-medium text-gray-500 hover:text-gray-900">
-        Cart
-      </a>
-      <button id="mobile-menu-toggle" class="-mr-2 inline-flex items-center justify-center rounded-md p-2 text-gray-400 hover:bg-gray-100 hover:text-gray-500 focus:outline-none focus:ring-2 focus:ring-inset focus:ring-indigo-500 md:hidden">
-        <span class="sr-only">Open main menu</span>
-        <svg class="h-6 w-6" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
-          <path stroke-linecap="round" stroke-linejoin="round" d="M3.75 6.75h16.5M3.75 12h16.5m-16.5 5.25h16.5" />
-        </svg>
-      </button>
-    </div>
-  </div>
-
-  <div id="mobile-menu" class="hidden md:hidden">
-    <div class="space-y-1 px-2 pb-3 pt-2">
-      {%- for link in main_menu.links -%}
-        <a href="{{ link.url }}" class="block rounded-md px-3 py-2 text-base font-medium text-gray-700 hover:bg-gray-50 hover:text-gray-900">
-          {{ link.title }}
-        </a>
-      {%- endfor -%}
+    <div class="header__icons">
+      <a href="{{ routes.search_url }}" aria-label="Search">{% render 'icon-search', class:'header__icon' %}</a>
+      <a href="{{ routes.account_url }}" aria-label="Account">{% render 'icon-account', class:'header__icon' %}</a>
+      <a href="{{ routes.cart_url }}" aria-label="Cart">{% render 'icon-cart', class:'header__icon' %}</a>
     </div>
   </div>
 </header>
-
-<script>
-  document.addEventListener('DOMContentLoaded', function () {
-    const mobileMenuToggle = document.getElementById('mobile-menu-toggle');
-    const mobileMenu = document.getElementById('mobile-menu');
-
-    if (mobileMenuToggle && mobileMenu) {
-      mobileMenuToggle.addEventListener('click', function () {
-        const isExpanded = mobileMenuToggle.getAttribute('aria-expanded') === 'true';
-        mobileMenuToggle.setAttribute('aria-expanded', !isExpanded);
-        mobileMenu.classList.toggle('hidden');
-      });
-    }
-  });
-</script>
-
-{% schema %}
-{
-  "name": "Header",
-  "class": "header-section-wrapper",
-  "settings": [
-    {
-      "type": "link_list",
-      "id": "menu",
-      "label": "Menu",
-      "default": "main-menu"
-    }
-  ]
-}
-{% endschema %}

--- a/snippets/icon-logo-aeh.liquid
+++ b/snippets/icon-logo-aeh.liquid
@@ -1,0 +1,3 @@
+<svg viewBox="0 0 100 100" class="{{ class }}" xmlns="http://www.w3.org/2000/svg">
+  <!-- insert exact AEH logo paths here -->
+</svg>


### PR DESCRIPTION
## Summary
- brand header with Auto Enhance Hub styles in `theme.css`
- rewrite `header.liquid` to use AEH header markup
- add `icon-logo-aeh` snippet placeholder

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68880a3c4b408323889b15e23a96907f