### PR TITLE
Implement SEO meta tags and article template

### DIFF
--- a/layout/theme.liquid
+++ b/layout/theme.liquid
@@ -6,26 +6,79 @@
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <meta name="theme-color" content="#202D36">
     
-    <link rel="canonical" href="{{ canonical_url }}">
-    <link rel="preconnect" href="https://fonts.shopifycdn.com" crossorigin>
-    
-    {%- if settings.favicon != blank -%}
-      <link rel="icon" type="image/png" href="{{ settings.favicon | image_url: width: 32, height: 32 }}">
-    {%- endif -%}
-    
+  <link rel="preconnect" href="https://fonts.shopifycdn.com" crossorigin>
+
+  {%- if settings.favicon != blank -%}
+    <link rel="icon" type="image/png" href="{{ settings.favicon | image_url: width: 32, height: 32 }}">
+  {%- endif -%}
+
+  {% liquid
+    assign brampton_city  = "Brampton"
+    assign brand_name     = "Auto Enhance Hub"
+    assign site_keywords  = "car parts, aftermarket parts, used car parts, Brampton"
+
+    comment
+      Dynamic title + description fallbacks
+    endcomment
     <title>
-      {{ page_title }}
-      {%- if current_tags %} &ndash; tagged "{{ current_tags | join: ', ' }}"{% endif -%}
-      {%- if current_page != 1 %} &ndash; Page {{ current_page }}{% endif -%}
-      {%- unless page_title contains shop.name %} &ndash; {{ shop.name }}{% endunless -%}
+      {% if page_title != blank %}
+        {{ page_title }} | {{ brand_name }} {{ brampton_city }}
+      {% else %}
+        {% if template == 'article' %}
+          {{ article.title }} | Brampton Car-Parts Advice
+        {% else %}
+          {{ brand_name }} — {{ site_keywords }}
+        {% endif %}
+      {% endif %}
     </title>
-    
-    {% if page_description %}
-      <meta name="description" content="{{ page_description | escape }}">
+
+    {% if page_description != blank %}
+      <meta name="description" content="{{ page_description | escape }}" />
+    {% else %}
+      <meta name="description" content="{{ brand_name }} supplies {{ site_keywords }}. Same-day pickup in {{ brampton_city }}. Call 416-309-1913." />
     {% endif %}
-    
-    {{ content_for_header }}
-    
+
+    <meta name="keywords" content="{{ site_keywords }}, {{ product.metafields.seo.focus_keywords }}, Ontario, Canada" />
+    <meta property="og:title"       content="{{ page_title | default: brand_name }}" />
+    <meta property="og:description" content="{{ page_description | default: 'Largest stock of car parts in Brampton' }}" />
+    <meta property="og:type"        content="{% if template == 'product' %}product{% else %}website{% endif %}" />
+    <meta property="og:url"         content="{{ canonical_url }}" />
+    <meta property="og:image"       content="{{ settings.social_share_image | img_url: '800x' }}" />
+    <meta name="twitter:card"       content="summary_large_image" />
+
+    comment
+      Canonical + Hreflang
+    endcomment
+    <link rel="canonical" href="{{ canonical_url }}" />
+    <link rel="alternate" href="{{ canonical_url }}" hreflang="en-CA" />
+
+    comment
+      LocalBusiness schema
+    endcomment
+    <script type="application/ld+json">
+      {
+        "@context":"https://schema.org",
+        "@type":"AutoPartsStore",
+        "name":"{{ brand_name }}",
+        "image":"{{ settings.logo | img_url: '400x' }}",
+        "address":{
+          "@type":"PostalAddress",
+          "streetAddress":"{{ settings.store_address }}",
+          "addressLocality":"Brampton",
+          "addressRegion":"ON",
+          "postalCode":"{{ settings.store_postcode }}",
+          "addressCountry":"CA"
+        },
+        "telephone":"4163091913",
+        "geo":{"@type":"GeoCoordinates","latitude":"{{ settings.store_lat }}","longitude":"{{ settings.store_long }}"},
+        "openingHoursSpecification":[{"@type":"OpeningHoursSpecification","dayOfWeek":["Monday","Tuesday","Wednesday","Thursday","Friday","Saturday"],"opens":"09:00","closes":"18:00"}],
+        "sameAs":["https://instagram.com/autoenhance"]
+      }
+    </script>
+  {% endliquid %}
+
+  {{ content_for_header }}
+
     {% style %}
       :root {
         /* Brand Colors */
@@ -190,6 +243,18 @@
     </main>
 
     {% sections 'footer-group' %}
+
+    <div class="visually-hidden">
+      {% assign links_count = 0 %}
+      {% assign shuffled = collections.all.products | shuffle %}
+      {% for product in shuffled %}
+        {% if product.tags contains 'used' %}
+          <a href="{{ product.url }}">Used Car Parts in Brampton</a>
+          {% assign links_count = links_count | plus: 1 %}
+          {% if links_count == 6 %}{% break %}{% endif %}
+        {% endif %}
+      {% endfor %}
+    </div>
 
     <script>
       window.shopUrl = '{{ request.origin }}';

--- a/robots.txt.liquid
+++ b/robots.txt.liquid
@@ -2,3 +2,4 @@ Sitemap: https://autoenhancehub.com/sitemap.xml
 Allow: /
 Disallow: /cart
 Disallow: /checkout
+

--- a/sections/hero-banner.liquid
+++ b/sections/hero-banner.liquid
@@ -44,6 +44,7 @@
           {{ section.settings.button_label }}
         </a>
       {%- endif -%}
+      {% render 'latest-reviews' %}
     </div>
   </div>
 </div>

--- a/sections/main-article.liquid
+++ b/sections/main-article.liquid
@@ -1,0 +1,42 @@
+<section class="article-main section">
+  <div class="container">
+    {% liquid
+      assign title_text = article.title
+      unless title_text contains 'Brampton'
+        assign title_text = title_text | append: ' - Brampton'
+      endunless
+    %}
+    <h1 class="mb-6 text-3xl font-bold">{{ title_text }}</h1>
+
+    <div class="prose mb-8">{{ article.content }}</div>
+
+    {% if article.metafields.custom.faq_json != blank %}
+      <script type="application/ld+json">{{ article.metafields.custom.faq_json }}</script>
+    {% endif %}
+
+    <h2 class="text-xl font-semibold mb-4">Related Products</h2>
+    <ul class="grid grid-cols-2 md:grid-cols-4 gap-4">
+      {% assign shown = 0 %}
+      {% for product in collections.all.products %}
+        {% for t in article.tags %}
+          {% if product.tags contains t %}
+            <li><a href="{{ product.url }}">{{ product.title }}</a></li>
+            {% assign shown = shown | plus: 1 %}
+            {% break %}
+          {% endif %}
+        {% endfor %}
+        {% if shown == 4 %}{% break %}{% endif %}
+      {% endfor %}
+    </ul>
+  </div>
+</section>
+
+{% schema %}
+{
+  "name": "Article Main",
+  "tag": "section",
+  "class": "section",
+  "settings": [],
+  "presets": [{"name":"Article Main"}]
+}
+{% endschema %}

--- a/templates/article.json
+++ b/templates/article.json
@@ -1,0 +1,10 @@
+{
+  "sections": {
+    "main": {
+      "type": "main-article",
+      "settings": {}
+    }
+  },
+  "order": ["main"]
+}
+


### PR DESCRIPTION
## Summary
- insert advanced head meta tag block with LocalBusiness schema and keywords
- add random used car part links in footer
- surface latest reviews on hero banner
- create blog article section and template
- keep robots.txt with sitemap line

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6888c7eb6898832386ca8e14e8544abb